### PR TITLE
fix: Correctly list runs for RUN_TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: macro copy-final
 PDK_ROOT ?= ~/.ciel
 PDK ?= ihp-sg13g2
 
-RUN_TAG = $(shell ls librelane/runs/ -1 | tail -n 1)
+RUN_TAG = $(shell ls librelane/runs/ | tail -n 1)
 
 # Macro - LibreLane
 


### PR DESCRIPTION
The previous implementation uses the `-1` in an incorrect position, resulting in an error message that `-1` can not be found. It would need to be before the path argument.
But it is save to remove because in the pipe environment, `ls` returns the result in a single line format anyway.