### PR TITLE
Add support for the RealDigital Boolean development board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,39 @@ basys3.frames: basys3.fasm
 basys3.bit: basys3.frames
 	xc7frames2bit --part_file ${PRJXRAY_DB_DIR}/artix7/xc7a35tcpg236-1/part.yaml --part_name xc7a35tcpg236-1 --frm_file $< --output_file $@
 
+
+## RealDigital Boolean
+
+BOOLEAN_SOURCES = $(wildcard fpga/boolean/*.sv) $(wildcard src/*.sv)
+
+synth-boolean: boolean.json
+
+pnr-boolean: boolean.bit
+
+# We abuse the ArtyS7 here as it's similar
+upload-boolean: boolean.bit
+	openFPGALoader --board=arty_s7_50 boolean.bit
+
+boolean.json: $(BOOLEAN_SOURCES)
+	yosys -l $(basename $@)-yosys.log -DSYNTHESIS -DBOOLEAN -p "synth_xilinx -flatten -abc9 ${SYNTH_OPTS} -arch xc7 -top boolean_top; write_json boolean.json" $^
+
+# The chip database only needs to be generated once
+# that is why we don't clean it with make clean
+nix-openxc7/xc7s50csga324.bin:
+	pypy3 ${NEXTPNR_XILINX_PYTHON_DIR}/bbaexport.py --device xc7s50csga324-1 --bba xc7s50csga324.bba
+	bbasm -l xc7s50csga324.bba nix-openxc7/xc7s50csga324.bin
+	rm -f xc7s50csga324.bba
+
+boolean.fasm: boolean.json nix-openxc7/xc7s50csga324.bin fpga/boolean/boolean.xdc
+	nextpnr-xilinx --chipdb nix-openxc7/xc7s50csga324.bin --xdc fpga/boolean/boolean.xdc --json boolean.json --fasm $@ ${PNR_ARGS} ${PNR_DEBUG}
+	
+boolean.frames: boolean.fasm
+	fasm2frames --part xc7s50csga324-1 --db-root ${PRJXRAY_DB_DIR}/spartan7 $< > $@
+
+boolean.bit: boolean.frames
+	xc7frames2bit --part_file ${PRJXRAY_DB_DIR}/spartan7/xc7s50csga324-1/part.yaml --part_name xc7s50csga324-1 --frm_file $< --output_file $@
+
+
 # Common
 
 clean:
@@ -167,4 +200,5 @@ clean:
 	rm -f icebreaker.json icebreaker.asc icebreaker.bit icebreaker-yosys.log
 	rm -f ulx3s.json ulx3s.config ulx3s.bit ulx3s-yosys.log
 	rm -f basys3.json basys3.bin basys3.fasm basys3.frames basys3.bit basys3-yosys.log
+	rm -f boolean.json boolean.bin boolean.fasm boolean.frames boolean.bit boolean-yosys.log
 	rm -f nano9k.json nano9k.bin nano9k.fasm nano9k.frames nano9k.fs nano9k-yosys.log nano9k_pnr.json

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following FPGA boards are supported by the Makefile:
 - [iCE40HX8K-EVB](https://www.olimex.com/Products/FPGA/iCE40/iCE40HX8K-EVB/)
 - [Tang Nano 9K](https://wiki.sipeed.com/hardware/en/tang/Tang-Nano-9K/Nano-9K.html)
 - [Basys 3](https://digilent.com/reference/programmable-logic/basys-3/start)
+- [Boolean](https://www.realdigital.org/hardware/boolean)
 
 > [!IMPORTANT]
 > You have to edit the top-level module under `fpga/<board_name>/<board_name>_top.sv` for your FPGA board so that it is compatible with your HeiChips design.
@@ -115,7 +116,7 @@ make upload-ulx3s
 ```
 
 > [!IMPORTANT]
-> Support for Basys 3 (Artix7) is not yet upstreamed in nextpnr. Thus we make use of the excellent [openXC7](https://github.com/openxc7) project, which provides a fork of nextpnr called `nextpnr-xilinx`.
+> Support for Basys 3 (Artix7) and Boolean (Spartan 7) is not yet upstreamed in nextpnr. Thus we make use of the excellent [openXC7](https://github.com/openxc7) project, which provides a fork of nextpnr called `nextpnr-xilinx`.
 > However, this also means that the setup is slightly different. Instead of invoking `nix-shell` at the root of this repository, you need to invoke `nix-shell` inside of `nix-opencx7/`.
 
 The make targets for Basys 3 are:
@@ -124,6 +125,14 @@ The make targets for Basys 3 are:
 make synth-basys3
 make pnr-basys3
 make upload-basys3
+```
+
+The make targets for Boolean are:
+
+```
+make synth-boolean
+make pnr-boolean
+make upload-boolean
 ```
 
 

--- a/fpga/boolean/boolean.xdc
+++ b/fpga/boolean/boolean.xdc
@@ -1,0 +1,97 @@
+# clk input is from the 100 MHz oscillator on Boolean board
+#create_clock -period 10.000 -name gclk [get_ports clk_100MHz]
+set_property -dict {PACKAGE_PIN F14 IOSTANDARD LVCMOS33} [get_ports {clk}]
+
+# On-board Slide Switches
+set_property -dict {PACKAGE_PIN V2 IOSTANDARD LVCMOS33} [get_ports {sw[0]}]
+set_property -dict {PACKAGE_PIN U2 IOSTANDARD LVCMOS33} [get_ports {sw[1]}]
+set_property -dict {PACKAGE_PIN U1 IOSTANDARD LVCMOS33} [get_ports {sw[2]}]
+set_property -dict {PACKAGE_PIN T2 IOSTANDARD LVCMOS33} [get_ports {sw[3]}]
+set_property -dict {PACKAGE_PIN T1 IOSTANDARD LVCMOS33} [get_ports {sw[4]}]
+set_property -dict {PACKAGE_PIN R2 IOSTANDARD LVCMOS33} [get_ports {sw[5]}]
+set_property -dict {PACKAGE_PIN R1 IOSTANDARD LVCMOS33} [get_ports {sw[6]}]
+set_property -dict {PACKAGE_PIN P2 IOSTANDARD LVCMOS33} [get_ports {sw[7]}]
+set_property -dict {PACKAGE_PIN P1 IOSTANDARD LVCMOS33} [get_ports {sw[8]}]
+set_property -dict {PACKAGE_PIN N2 IOSTANDARD LVCMOS33} [get_ports {sw[9]}]
+set_property -dict {PACKAGE_PIN N1 IOSTANDARD LVCMOS33} [get_ports {sw[10]}]
+set_property -dict {PACKAGE_PIN M2 IOSTANDARD LVCMOS33} [get_ports {sw[11]}]
+set_property -dict {PACKAGE_PIN M1 IOSTANDARD LVCMOS33} [get_ports {sw[12]}]
+set_property -dict {PACKAGE_PIN L1 IOSTANDARD LVCMOS33} [get_ports {sw[13]}]
+set_property -dict {PACKAGE_PIN K2 IOSTANDARD LVCMOS33} [get_ports {sw[14]}]
+set_property -dict {PACKAGE_PIN K1 IOSTANDARD LVCMOS33} [get_ports {sw[15]}]
+
+# On-board LEDs
+set_property -dict {PACKAGE_PIN G1 IOSTANDARD LVCMOS33} [get_ports {led[0]}]
+set_property -dict {PACKAGE_PIN G2 IOSTANDARD LVCMOS33} [get_ports {led[1]}]
+set_property -dict {PACKAGE_PIN F1 IOSTANDARD LVCMOS33} [get_ports {led[2]}]
+set_property -dict {PACKAGE_PIN F2 IOSTANDARD LVCMOS33} [get_ports {led[3]}]
+set_property -dict {PACKAGE_PIN E1 IOSTANDARD LVCMOS33} [get_ports {led[4]}]
+set_property -dict {PACKAGE_PIN E2 IOSTANDARD LVCMOS33} [get_ports {led[5]}]
+set_property -dict {PACKAGE_PIN E3 IOSTANDARD LVCMOS33} [get_ports {led[6]}]
+set_property -dict {PACKAGE_PIN E5 IOSTANDARD LVCMOS33} [get_ports {led[7]}]
+set_property -dict {PACKAGE_PIN E6 IOSTANDARD LVCMOS33} [get_ports {led[8]}]
+set_property -dict {PACKAGE_PIN C3 IOSTANDARD LVCMOS33} [get_ports {led[9]}]
+set_property -dict {PACKAGE_PIN B2 IOSTANDARD LVCMOS33} [get_ports {led[10]}]
+set_property -dict {PACKAGE_PIN A2 IOSTANDARD LVCMOS33} [get_ports {led[11]}]
+set_property -dict {PACKAGE_PIN B3 IOSTANDARD LVCMOS33} [get_ports {led[12]}]
+set_property -dict {PACKAGE_PIN A3 IOSTANDARD LVCMOS33} [get_ports {led[13]}]
+set_property -dict {PACKAGE_PIN B4 IOSTANDARD LVCMOS33} [get_ports {led[14]}]
+set_property -dict {PACKAGE_PIN A4 IOSTANDARD LVCMOS33} [get_ports {led[15]}]
+
+# On-board Buttons
+set_property -dict {PACKAGE_PIN J2 IOSTANDARD LVCMOS33} [get_ports {btn[0]}]
+set_property -dict {PACKAGE_PIN J5 IOSTANDARD LVCMOS33} [get_ports {btn[1]}]
+set_property -dict {PACKAGE_PIN H2 IOSTANDARD LVCMOS33} [get_ports {btn[2]}]
+set_property -dict {PACKAGE_PIN J1 IOSTANDARD LVCMOS33} [get_ports {btn[3]}]
+
+# On-board color LEDs
+set_property -dict {PACKAGE_PIN V6 IOSTANDARD LVCMOS33} [get_ports {RGB0[0]}]
+set_property -dict {PACKAGE_PIN V4 IOSTANDARD LVCMOS33} [get_ports {RGB0[1]}]
+set_property -dict {PACKAGE_PIN U6 IOSTANDARD LVCMOS33} [get_ports {RGB0[2]}]
+set_property -dict {PACKAGE_PIN U3 IOSTANDARD LVCMOS33} [get_ports {RGB1[0]}]
+set_property -dict {PACKAGE_PIN V3 IOSTANDARD LVCMOS33} [get_ports {RGB1[1]}]
+set_property -dict {PACKAGE_PIN V5 IOSTANDARD LVCMOS33} [get_ports {RGB1[2]}]
+
+# On-board 7-Segment display 0
+set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33} [get_ports {D0_AN[0]}]
+set_property -dict {PACKAGE_PIN C4 IOSTANDARD LVCMOS33} [get_ports {D0_AN[1]}]
+set_property -dict {PACKAGE_PIN C7 IOSTANDARD LVCMOS33} [get_ports {D0_AN[2]}]
+set_property -dict {PACKAGE_PIN A8 IOSTANDARD LVCMOS33} [get_ports {D0_AN[3]}]
+set_property -dict {PACKAGE_PIN D7 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[0]}]
+set_property -dict {PACKAGE_PIN C5 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[1]}]
+set_property -dict {PACKAGE_PIN A5 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[2]}]
+set_property -dict {PACKAGE_PIN B7 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[3]}]
+set_property -dict {PACKAGE_PIN A7 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[4]}]
+set_property -dict {PACKAGE_PIN D6 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[5]}]
+set_property -dict {PACKAGE_PIN B5 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[6]}]
+set_property -dict {PACKAGE_PIN A6 IOSTANDARD LVCMOS33} [get_ports {D0_SEG[7]}]
+
+# On-board 7-Segment display 1
+set_property -dict {PACKAGE_PIN H3 IOSTANDARD LVCMOS33} [get_ports {D1_AN[0]}]
+set_property -dict {PACKAGE_PIN J4 IOSTANDARD LVCMOS33} [get_ports {D1_AN[1]}]
+set_property -dict {PACKAGE_PIN F3 IOSTANDARD LVCMOS33} [get_ports {D1_AN[2]}]
+set_property -dict {PACKAGE_PIN E4 IOSTANDARD LVCMOS33} [get_ports {D1_AN[3]}]
+set_property -dict {PACKAGE_PIN F4 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[0]}]
+set_property -dict {PACKAGE_PIN J3 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[1]}]
+set_property -dict {PACKAGE_PIN D2 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[2]}]
+set_property -dict {PACKAGE_PIN C2 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[3]}]
+set_property -dict {PACKAGE_PIN B1 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[4]}]
+set_property -dict {PACKAGE_PIN H4 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[5]}]
+set_property -dict {PACKAGE_PIN D1 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[6]}]
+set_property -dict {PACKAGE_PIN C1 IOSTANDARD LVCMOS33} [get_ports {D1_SEG[7]}]
+
+# UART
+set_property -dict {PACKAGE_PIN V12 IOSTANDARD LVCMOS33} [get_ports {UART_rxd}]
+set_property -dict {PACKAGE_PIN U11 IOSTANDARD LVCMOS33} [get_ports {UART_txd}]
+
+#HDMI Signals
+set_property -dict { PACKAGE_PIN T14   IOSTANDARD TMDS_33 } [get_ports {hdmi_clk_n}]
+set_property -dict { PACKAGE_PIN R14   IOSTANDARD TMDS_33 } [get_ports {hdmi_clk_p}]
+
+set_property -dict { PACKAGE_PIN T15   IOSTANDARD TMDS_33  } [get_ports {hdmi_tx_n[0]}]
+set_property -dict { PACKAGE_PIN R17   IOSTANDARD TMDS_33  } [get_ports {hdmi_tx_n[1]}]
+set_property -dict { PACKAGE_PIN P16   IOSTANDARD TMDS_33  } [get_ports {hdmi_tx_n[2]}]
+                                    
+set_property -dict { PACKAGE_PIN R15   IOSTANDARD TMDS_33  } [get_ports {hdmi_tx_p[0]}]
+set_property -dict { PACKAGE_PIN R16   IOSTANDARD TMDS_33  } [get_ports {hdmi_tx_p[1]}]
+set_property -dict { PACKAGE_PIN N15   IOSTANDARD TMDS_33  } [get_ports {hdmi_tx_p[2]}]

--- a/fpga/boolean/boolean_top.sv
+++ b/fpga/boolean/boolean_top.sv
@@ -1,0 +1,48 @@
+module boolean_top (
+    input  logic        clk, // 100 MHz
+
+    input  logic [15:0] sw,
+    output logic [15:0] led,
+    input  logic [3:0]  btn,
+    
+    // HDMI
+    //output  logic [2:0]  hdmi_tx_p,
+    //output  logic [2:0]  hdmi_tx_n,
+    //output  logic        hdmi_clk_n, hdmi_clk_p,
+
+    // RGB LEDs
+    output logic  [2:0]  RGB0, RGB1  
+);
+
+    //logic clk;
+    logic rst_n;
+    logic ena;
+    logic [7:0] ui_in;
+    logic [7:0] uio_in;
+    logic [7:0] uo_out;
+    logic [7:0] uio_out;
+    logic [7:0] uio_oe;
+    
+    heichips25_template heichips25_template (
+        .ui_in  (ui_in),    // Dedicated inputs
+        .uo_out (uo_out),   // Dedicated outputs
+        .uio_in (uio_in),   // IOs: Input path
+        .uio_out(uio_out),  // IOs: Output path
+        .uio_oe (uio_oe),   // IOs: Enable path (active high: 0=input, 1=output)
+        .ena    (ena),      // enable - goes high when design is selected
+        .clk    (clk),      // clock
+        .rst_n  (rst_n)     // not reset
+    );
+    
+    // Assignments
+
+    assign ui_in = sw[7:0];
+    assign uio_in = sw[15:8];
+    
+    assign led[7:0] = uo_out;
+    assign led[15:8] = uio_out;
+    
+    assign ena = 1'b1;
+    assign rst_n = !btn[0];
+
+endmodule


### PR DESCRIPTION
This PR adds support for the [RealDigital Boolean](https://www.realdigital.org/hardware/boolean) (a low-cost Spartan 7-based dev board with a HDMI output).