### PR TITLE
flake.nix : add pytest line after cocotb line

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
         extra-python-packages = with pkgs.python3.pkgs; (pkgs.lib.optionals pkgs.stdenv.isLinux [
           # Verification
           cocotb
+          pytest
         ]);
       }) {};
     });


### PR DESCRIPTION
Include `pytest` to `flake.nix` to improve assert reporting in a `cocotb` test base.